### PR TITLE
Enhancements

### DIFF
--- a/org-z.el
+++ b/org-z.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/landakram/org-z
 ;; Keywords: org-mode
 ;; Package-Version: 0.0.1
-;; Package-Requires: ((emacs "26.1") (org "9.3") (helm-org-rifle "1.7.1") (helm-rg "0.1"))
+;; Package-Requires: ((emacs "26.1") (org "9.3") (helm-org-rifle "1.7.1") (helm-rg "0.1") (dash "2.12") (f "0.18.1") (s "1.10.0"))
 ;; Keywords: (outlines)
 
 ;;; Commentary:
@@ -20,6 +20,9 @@
 (require 'org-capture)
 (require 'helm-org-rifle)
 (require 'helm-rg)
+(require 'dash)
+(require 'f)
+(require 's)
 
 (defgroup org-z nil
   "org-z customizable variables."

--- a/org-z.el
+++ b/org-z.el
@@ -28,7 +28,12 @@
   "org-z customizable variables."
   :group 'org)
 
-(defcustom org-z-new-headings-file (concat org-directory "/" "new.org")
+(defcustom org-z-directories (list org-directory)
+  "Directories in which org-z will look for org files."
+  :type 'list
+  :group 'org-z)
+
+(defcustom org-z-new-headings-file (f-join org-directory "new.org")
   "File in which to write new headings when inserting a link to a heading that does not already exist."
   :type 'file
   :group 'org-z)
@@ -41,7 +46,10 @@
        :immediate-finish t))))
 
 (defcustom org-z-capture-templates #'org-z-capture--templates
-  "The capture templates used by org-z to create a heading when inserting a link to a heading that doesn't exist."
+  "The capture templates used by org-z to create a heading when inserting a link to a
+heading that doesn't exist. This is a function which returns a list of capture templates
+using the same syntax as `org-capture-templates'. The function accepts a single string
+argument, which is the missing heading."
   :type 'function
   :group 'org-z)
 
@@ -132,14 +140,13 @@
 
   (let* ((helm-candidate-separator " ")
          (helm-cleanup-hook (org-z--org-rifle-cleanup-hook))
-         (org-rifle-sources (org-z--org-rifle-files-source (org-z--list-org-files (list org-directory)))))
+         (org-rifle-sources (org-z--org-rifle-files-source (org-z--list-org-files org-z-directories))))
     (add-to-list 'helm-org-rifle-actions '("Insert link" . org-z-helm-org-rifle--insert-link))
     (helm
      :input (thing-at-point 'symbol 'no-properties)
      :sources (append org-rifle-sources (list org-z-insert-link--fallback))
      :buffer "*org-z-insert-link*")
     (pop helm-org-rifle-actions)))
-
 
 (defun org-z-knowledge--search (targets &optional rg-opts)
   (let ((helm-rg-default-extra-args rg-opts)
@@ -149,7 +156,7 @@
      nil
      targets)))
 
-(defcustom org-z-knowledge-dirs (list org-directory "/Users/mark/Dropbox (Personal)/Apps/KiwiApp/wiki/")
+(defcustom org-z-knowledge-dirs org-z-directories
   "Directories in which to perform full-text knowledge search."
   :type 'list
   :group 'org-z)
@@ -167,7 +174,6 @@
                                   `("-t" ,ft))
                                 org-z-knowledge-filetypes))))
     (org-z-knowledge--search org-z-knowledge-dirs rg-opts)))
-
 
 ;;;###autoload
 (define-minor-mode org-z-mode

--- a/org-z.el
+++ b/org-z.el
@@ -73,9 +73,11 @@ argument, which is the missing heading."
         (point (org-capture-get :insertion-point)))
     (with-current-buffer buf
       (save-excursion
-        (goto-char point)
-        (call-interactively 'org-store-link)))
-    (remove-hook 'org-capture-before-finalize-hook #'org-z-capture--before-finalize-hook)))
+        (save-restriction
+          (widen)
+          (goto-char point)
+          (call-interactively 'org-store-link)))))
+  (remove-hook 'org-capture-before-finalize-hook #'org-z-capture--before-finalize-hook))
 
 (defun org-z-capture--after-finalize-hook ()
   "After org-z-capture, insert a link."


### PR DESCRIPTION
- Be explicit about dependencies
- Allow customizing the directories in which org-z looks for org files 
- Use f-join rather than concat to support cross-platform file paths
- Fix incorrect link description for empty new.org