### PR TITLE
Fix completion backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+test/*/**
+!test/*/**/init.el

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,4 +1,11 @@
 * Changelog
+** v0.0.3
+*** Bug fixes
+**** Fix completion backends
+***** Fix missing imports
+These were causing errors like: ~Symbol's function definition is void: org-ql-search-directories-files~.
+***** Fix helm backend not showing results
+Because ~org-z--format-org-ql-heading~ returned a cons cell, ~org-ql-select~ tried to flatten it and failed silently due to ~ignore-errors~. Return text with a point-marker property instead.
 ** v0.0.2
 *** Breaking changes
 **** Completion backends

--- a/org-z-helm.el
+++ b/org-z-helm.el
@@ -42,6 +42,7 @@
 (require 'org-z)
 
 (require 'org-ql)
+(require 'org-ql-search)
 (require 'helm-org-ql)
 
 (defun org-z-insert-link--fallback ()

--- a/org-z-helm.el
+++ b/org-z-helm.el
@@ -5,8 +5,8 @@
 ;; Author: Mark Hudnall <me@markhudnall.com>
 ;; URL: https://github.com/landakram/org-z
 ;; Keywords: org-mode
-;; Version: 0.0.2
-;; Package-Requires: ((emacs "27.1") (org-z "0.0.2") (org-ql "0.6-pre") (helm "3.3") (helm-org "1.0"))
+;; Version: 0.0.3
+;; Package-Requires: ((emacs "27.1") (org-z "0.0.2") (org-ql "0.6-pre") (helm "3.3") (helm-org "1.0") (helm-org-ql "0.6-pre"))
 ;; Keywords: org-mode, outlines
 
 ;; This file is NOT part of GNU Emacs.
@@ -68,10 +68,13 @@
                     (when query
                       (with-current-buffer (helm-buffer-get)
                         (setq helm-org-ql-buffers-files buffers-files))
+                      ;; Ignore errors that might be caused by partially typed queries.
                       (ignore-errors
-                        ;; Ignore errors that might be caused by partially typed queries.
-                        (org-ql-select buffers-files query
-                          :action `(org-z--format-org-ql-heading ,window-width))))))
+                        (mapcar (lambda (candidate)
+                                  (let ((point-marker (get-text-property 0 'point-marker candidate)))
+                                    (cons candidate point-marker)))
+                                (org-ql-select buffers-files query
+                                  :action `(org-z--format-org-ql-heading ,window-width)))))))
     :match #'identity
     :filtered-candidate-transformer #'org-z-helm-candidate-transformer
     :fuzzy-match nil

--- a/org-z-selectrum.el
+++ b/org-z-selectrum.el
@@ -40,6 +40,8 @@
 
 (require 'org-z)
 
+(require 'org-ql)
+(require 'org-ql-search)
 (require 'selectrum)
 
 (cl-defstruct org-z--selectrum-backend)

--- a/org-z-selectrum.el
+++ b/org-z-selectrum.el
@@ -4,7 +4,7 @@
 
 ;; Author: Mark Hudnall <me@markhudnall.com>
 ;; URL: https://github.com/landakram/org-z
-;; Version: 0.0.2
+;; Version: 0.0.3
 ;; Package-Requires: ((emacs "27.1") (org-z "0.0.2") (org-ql "0.6-pre") (selectrum "3.0"))
 ;; Keywords: org-mode, outlines
 
@@ -57,12 +57,8 @@
                            (when query
                              (ignore-errors
                                ;; Ignore errors that might be caused by partially typed queries.
-                               (mapcar (lambda (candidate)
-                                         (propertize (car candidate)
-                                                     'point-marker
-                                                     (cdr candidate)))
-                                       (org-ql-select buffers-files query
-                                         :action `(org-z--format-org-ql-heading ,window-width))))))))
+                               (org-ql-select buffers-files query
+                                 :action `(org-z--format-org-ql-heading ,window-width)))))))
          (result (selectrum-read "Insert link: " candidate-fn
                                  :initial-input (thing-at-point 'symbol 'no-properties))))
     (if-let ((point-marker (get-text-property 0 'point-marker result)))

--- a/org-z.el
+++ b/org-z.el
@@ -5,7 +5,7 @@
 ;; Author: Mark Hudnall <me@markhudnall.com>
 ;; URL: https://github.com/landakram/org-z
 ;; Keywords: org-mode
-;; Version: 0.0.2
+;; Version: 0.0.3
 ;; Package-Requires: ((emacs "27.1") (org "9.3") (dash "2.12") (f "0.18.1") (s "1.10.0"))
 ;; Keywords: org-mode, outlines
 
@@ -188,7 +188,10 @@ WINDOW-WIDTH should be the width of the window."
                    (org-format-outline-path width nil "")
                    (org-split-string "")))
          (path (concat (s-join "/" path) "/" heading)))
-    (cons (concat prefix path) (point-marker))))
+    (propertize
+     (concat prefix path)
+     'point-marker
+     (point-marker))))
 
 (cl-defstruct org-z--completion-backend
   org-z--insert-link)

--- a/test/helm/init.el
+++ b/test/helm/init.el
@@ -1,0 +1,36 @@
+(setq user-init-file (or load-file-name (buffer-file-name)))
+(setq user-emacs-directory (file-name-directory user-init-file))
+
+(require 'package)
+(add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t)
+(setq package-enable-at-startup nil)
+(package-initialize)
+(when (not package-archive-contents)
+  (package-refresh-contents))
+
+(defvar bootstrap-version)
+(let ((bootstrap-file
+       (expand-file-name "straight/repos/straight.el/bootstrap.el" user-emacs-directory))
+      (bootstrap-version 5))
+  (unless (file-exists-p bootstrap-file)
+    (with-current-buffer
+        (url-retrieve-synchronously
+         "https://raw.githubusercontent.com/raxod502/straight.el/develop/install.el"
+         'silent 'inhibit-cookies)
+      (goto-char (point-max))
+      (eval-print-last-sexp)))
+  (load bootstrap-file nil 'nomessage))
+
+(straight-use-package 'use-package)
+
+(use-package helm
+  :straight t)
+
+(package-install-file "org-z.el")
+(package-install-file "org-z-helm.el")
+
+(use-package org-z
+  :config
+  (org-z-mode 1))
+
+(use-package org-z-helm)

--- a/test/selectrum/init.el
+++ b/test/selectrum/init.el
@@ -1,0 +1,36 @@
+(setq user-init-file (or load-file-name (buffer-file-name)))
+(setq user-emacs-directory (file-name-directory user-init-file))
+
+(require 'package)
+(add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t)
+(setq package-enable-at-startup nil)
+(package-initialize)
+(when (not package-archive-contents)
+  (package-refresh-contents))
+
+(defvar bootstrap-version)
+(let ((bootstrap-file
+       (expand-file-name "straight/repos/straight.el/bootstrap.el" user-emacs-directory))
+      (bootstrap-version 5))
+  (unless (file-exists-p bootstrap-file)
+    (with-current-buffer
+        (url-retrieve-synchronously
+         "https://raw.githubusercontent.com/raxod502/straight.el/develop/install.el"
+         'silent 'inhibit-cookies)
+      (goto-char (point-max))
+      (eval-print-last-sexp)))
+  (load bootstrap-file nil 'nomessage))
+
+(straight-use-package 'use-package)
+
+(use-package selectrum
+  :straight t)
+
+(package-install-file "org-z.el")
+(package-install-file "org-z-selectrum.el")
+
+(use-package org-z
+  :config
+  (org-z-mode 1))
+
+(use-package org-z-selectrum)


### PR DESCRIPTION
*  Fix missing import. This was causing an error: `Symbol's function definition is void: org-ql-search-directories-files`.
*  Fix helm backend not showing results
    - Because org-z--format-org-ql-heading returned a cons cell, org-ql-select tried to
  flatten it and failed silently due to ignore-errors. Return text with a point-marker
  property instead.
    - Fix another missing import
- Add clean configs for testing backends. These can be used with e.g. `emacs -Q -l test/helm/init.el` in the project root.

Closes https://github.com/landakram/org-z/issues/5

