### PR TITLE
Backlinks

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,4 +1,15 @@
 * Changelog
+** v0.0.5
+*** Features
+**** Backlinks
+:PROPERTIES:
+:ID:       a08e2a03-19be-46b0-96fc-43a6556e3710
+:END:
+ - Add a function ~org-z-backlinks-at-point~ that can be used to inspect backlinks to the current headline. This function uses completing-read to allow jumping through a backlink. This function is not bound to any key by default, leaving keybindings open to the user.
+
+ - If org-eldoc is loaded, show the number of backlinks for the current headline at point. This functionality can be turned off by unsetting ~org-z-show-backlinks~.
+
+   This function respects ~eldoc-echo-area-use-multiline-p~. If t, then the backlink message is always displayed on a new line. If truthy, message is displayed same line if there's space, or a new line if there is not enough space. If false, it is always displayed on single line (header path will be truncated).
 ** v0.0.4
 *** Bug fixes
 **** Fix org-z-selectrum
@@ -24,6 +35,6 @@ org-z now supports both Helm and Selectrum for completion. The completion backen
   (use-package org-z-selectrum
     :straight (org-z-selectrum :type git :host github :repo "landakram/org-z"))
 #+end_src
-*** Other changes
+*** Features
 **** Sort links with prescient.el
 Results can be optionally sorted with [[https://github.com/raxod502/prescient.el][prescient.el]] by setting ~org-z-use-prescient~. Note that if you already have prescient enabled through your completion system, you should leave this as nil. 

--- a/README.org
+++ b/README.org
@@ -6,13 +6,14 @@ Lightweight, Org-mode flavored zettelkasten links.
 
 org-z is an Emacs global minor mode that enables a lightweight, Org mode style zettelkasten. Unlike a traditional zettelkasten, org-z focuses on headings rather than pages, allowing you to make hyperlinks within a single Org mode document.
 
-By treating headings, rather than pages, as first-class, we can use standard functions that ship with org like [[https://orgmode.org/manual/Handling-Links.html][org-store-link]] and packages like [[https://github.com/alphapapa/org-sidebar][org-sidebar]] to maximum effect.
+By treating headings, rather than pages, as first-class, we can use standard functions that ship with org like [[https://orgmode.org/manual/Handling-Links.html][org-store-link]] to maximum effect.
 
 org-z has the following features:
 
  - Insert links to org headings with interactive search (~C-c-.~ by default). [[https://github.com/emacs-helm/helm][Helm]] and [[https://github.com/raxod502/selectrum][Selectrum]] are supported.
  - Links are managed automatically using [[https://orgmode.org/manual/Handling-Links.html][org-store-link]] and org-ids
  - Links to new / missing targets auto-create targets in a configurable file location (~new.org~ by default). Creation of the new heading is customizable using a capture template.
+ - [[./CHANGELOG.org#backlinks][Backlinks]] 
 
 #+CAPTION: Inserting a link to an existing heading
 #+NAME:   existing-heading
@@ -44,7 +45,7 @@ Loading the package sets the completion backend by appending to ~org-z-completio
 
 ** A lightweight zettelkasten
 
-I combine org-z with a daily journal, implemented as a ~file+datetree~ capture template, and [[https://github.com/alphapapa/org-sidebar][org-sidebar]] backlinks.
+I combine org-z with a daily journal, implemented as a ~file+datetree~ capture template, and [[./CHANGELOG.org#backlinks][org-z's support for backlinks]].
 
 #+begin_src emacs-lisp
   (setq org-capture-templates
@@ -52,15 +53,21 @@ I combine org-z with a daily journal, implemented as a ~file+datetree~ capture t
           ("j" "Journal entry" entry (file+datetree "~/org/journal.org")
            "* %?\n" :unnarrowed t)))
 
-  (use-package org-sidebar
-    :ensure t
-    :after (general)
+  (use-package org
+    :straight org-plus-contrib
     :config
+    (require 'org-eldoc))
+
+  (use-package org-z
+    :straight (org-z :type git :host github :repo "landakram/org-z")
+    :general
     (leader-def :infix "o"
-      "b" 'org-sidebar-backlinks))
+      "b" 'org-z-backlinks-at-point)
+    :config
+    (org-z-mode 1))
 #+end_src
 
-As I go about my day, I make journal entries that link to various headings in my collection of org files. I make these links by invoking ~org-z-insert-link~ as I write my journal entry. I periodically open the backlinks sidebar to investigate connections.
+As I go about my day, I make journal entries that link to various headings in my collection of org files. I make these links by invoking ~org-z-insert-link~ as I write my journal entry. I periodically inspect backlinks using ~org-z-backlinks-at-point~ to investigate connections. By enabling ~org-eldoc~, I get to see the # of backlinks for a given heading when I hover over it.
 
 Every once in a while, I review my journal entries and ~org-refile~ headings or simply re-organize journal entry knowledge into "longer-term storage" (~reference.org~ or ~projects.org~).
 

--- a/org-z.el
+++ b/org-z.el
@@ -5,7 +5,7 @@
 ;; Author: Mark Hudnall <me@markhudnall.com>
 ;; URL: https://github.com/landakram/org-z
 ;; Keywords: org-mode
-;; Version: 0.0.4
+;; Version: 0.0.5
 ;; Package-Requires: ((emacs "27.1") (org "9.3") (dash "2.12") (f "0.18.1") (s "1.10.0"))
 ;; Keywords: org-mode, outlines
 


### PR DESCRIPTION
Backlinks :star2: 

- Add a function `org-z-backlinks-at-point` that can be used to inspect backlinks to
  the current headline. This function uses `completing-read` to allow jumping through a
  backlink. This function is not bound to any key by default, leaving keybindings
  open to the user.

- If org-eldoc is loaded, show the number of backlinks for the current headline at
  point. This functionality can be turned off by unsetting `org-z-show-backlinks`.

  This function respects `eldoc-echo-area-use-multiline-p`. If t, then the backlink
  message is always displayed on a new line. If truthy, message is displayed same
  line if there's space, or a new line if there is not enough space. If false, it is
  always displayed on single line (header path will be truncated).